### PR TITLE
Feat/authentication middleware backend

### DIFF
--- a/backend/vibera/db_logging.py
+++ b/backend/vibera/db_logging.py
@@ -152,5 +152,3 @@ def log_connection_created(sender, connection, **kwargs):
         
         connection.cursor = wrapped_cursor
 
-
-        connection.close = wrapped_close

--- a/backend/vibera/middleware.py
+++ b/backend/vibera/middleware.py
@@ -15,7 +15,7 @@ from typing import Callable
 from django.conf import settings
 from django.http import HttpRequest, HttpResponse, JsonResponse
 from rest_framework_simplejwt.authentication import JWTAuthentication
-from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError, AuthenticationFailed
 
 from vibera.logging_config import RequestResponseLogger, get_logger
 
@@ -162,7 +162,7 @@ class JWTAuthenticationMiddleware:
         
         return parts[1]
 
-    def _authenticate_token(self, request: HttpRequest, token: str) -> tuple | None:
+    def _authenticate_token(self, request: HttpRequest, token: str) -> tuple | str | None:
         """
         Authenticate the JWT token and return user and token tuple.
 
@@ -171,7 +171,9 @@ class JWTAuthenticationMiddleware:
             token: The JWT token string
 
         Returns:
-            Tuple of (user, validated_token) if successful, None otherwise
+            Tuple of (user, validated_token) if successful,
+            'INACTIVE_USER' if user is inactive,
+            None otherwise
         """
         try:
             # Use DRF's JWT authentication to validate the token
@@ -180,6 +182,24 @@ class JWTAuthenticationMiddleware:
             return (user, validated_token)
         except (InvalidToken, TokenError) as e:
             # Log authentication failure without exposing token
+            logger.warning(
+                f"JWT authentication failed: {type(e).__name__} | "
+                f"Request: {request.method} {request.path} | "
+                f"IP: {request.META.get('REMOTE_ADDR', 'unknown')}"
+            )
+            return None
+        except AuthenticationFailed as e:
+            # Check if it's due to inactive user
+            error_detail = str(e)
+            if 'user_inactive' in error_detail or 'inactive' in error_detail.lower():
+                # Return special marker for inactive user
+                logger.warning(
+                    f"Inactive user attempted access | "
+                    f"Request: {request.method} {request.path} | "
+                    f"IP: {request.META.get('REMOTE_ADDR', 'unknown')}"
+                )
+                return 'INACTIVE_USER'
+            # Other authentication failures
             logger.warning(
                 f"JWT authentication failed: {type(e).__name__} | "
                 f"Request: {request.method} {request.path} | "
@@ -242,9 +262,19 @@ class JWTAuthenticationMiddleware:
                 status=401
             )
 
+        # Check if user is inactive (handled during authentication)
+        if auth_result == 'INACTIVE_USER':
+            return JsonResponse(
+                {
+                    "error": "Authentication required",
+                    "detail": "Invalid or expired token"
+                },
+                status=403
+            )
+
         user, validated_token = auth_result
 
-        # Check if user is active
+        # Additional check if user is active (defensive programming)
         if not user.is_active:
             logger.warning(
                 f"Inactive user attempted access | User: {user.username} | "

--- a/backend/vibera/middleware.py
+++ b/backend/vibera/middleware.py
@@ -1,5 +1,5 @@
 """
-Custom Django middleware for request/response logging.
+Custom Django middleware for request/response logging and JWT authentication.
 Logs all HTTP requests, responses, and exceptions with timing information.
 
 This middleware is synchronous and non-blocking because:
@@ -12,7 +12,10 @@ This middleware is synchronous and non-blocking because:
 import time
 from typing import Callable
 
-from django.http import HttpRequest, HttpResponse
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
 
 from vibera.logging_config import RequestResponseLogger, get_logger
 
@@ -88,3 +91,177 @@ class RequestResponseLoggingMiddleware:
             )
 
         return response
+
+
+class JWTAuthenticationMiddleware:
+    """
+    Middleware that validates JWT tokens for all API endpoints except public routes.
+    
+    This middleware:
+    - Checks if the request path is a public endpoint (configurable)
+    - For protected API routes, validates JWT tokens from the Authorization header
+    - Sets the authenticated user on the request object for DRF compatibility
+    - Returns appropriate error responses for authentication failures
+    - Logs security events without exposing sensitive token data
+    """
+
+    def __init__(self, get_response: Callable):
+        """
+        Initialize middleware.
+
+        Args:
+            get_response: The next middleware or view in the chain
+        """
+        self.get_response = get_response
+        self.jwt_authenticator = JWTAuthentication()
+        
+        # Get public paths from settings, with defaults
+        self.public_paths = getattr(
+            settings,
+            'API_AUTH_MIDDLEWARE_PUBLIC_PATHS',
+            [
+                '/api/auth/',
+                '/admin/',
+                '/api/users/auth/2fa/',
+            ]
+        )
+
+    def _is_public_path(self, path: str) -> bool:
+        """
+        Check if the request path is a public endpoint.
+
+        Args:
+            path: The request path
+
+        Returns:
+            True if the path is public, False otherwise
+        """
+        for public_path in self.public_paths:
+            if path.startswith(public_path):
+                return True
+        return False
+
+    def _extract_token(self, request: HttpRequest) -> str | None:
+        """
+        Extract JWT token from Authorization header.
+
+        Args:
+            request: The HTTP request
+
+        Returns:
+            The token string if found, None otherwise
+        """
+        auth_header = request.META.get('HTTP_AUTHORIZATION', '')
+        if not auth_header:
+            return None
+        
+        # Check for Bearer token format
+        parts = auth_header.split()
+        if len(parts) != 2 or parts[0].lower() != 'bearer':
+            return None
+        
+        return parts[1]
+
+    def _authenticate_token(self, request: HttpRequest, token: str) -> tuple | None:
+        """
+        Authenticate the JWT token and return user and token tuple.
+
+        Args:
+            request: The HTTP request
+            token: The JWT token string
+
+        Returns:
+            Tuple of (user, validated_token) if successful, None otherwise
+        """
+        try:
+            # Use DRF's JWT authentication to validate the token
+            validated_token = self.jwt_authenticator.get_validated_token(token)
+            user = self.jwt_authenticator.get_user(validated_token)
+            return (user, validated_token)
+        except (InvalidToken, TokenError) as e:
+            # Log authentication failure without exposing token
+            logger.warning(
+                f"JWT authentication failed: {type(e).__name__} | "
+                f"Request: {request.method} {request.path} | "
+                f"IP: {request.META.get('REMOTE_ADDR', 'unknown')}"
+            )
+            return None
+        except Exception as e:
+            # Log unexpected errors
+            logger.error(
+                f"Unexpected error during JWT authentication: {type(e).__name__} - {str(e)} | "
+                f"Request: {request.method} {request.path}",
+                exc_info=True
+            )
+            return None
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """
+        Process request and validate JWT authentication for protected endpoints.
+
+        Args:
+            request: The HTTP request
+
+        Returns:
+            HTTP response (either error response or passes to next middleware)
+        """
+        # Only apply authentication to API routes
+        # Non-API routes (like admin, static files) are handled by other middleware
+        if not request.path.startswith('/api/'):
+            return self.get_response(request)
+
+        # Check if this is a public endpoint
+        if self._is_public_path(request.path):
+            return self.get_response(request)
+
+        # For protected API endpoints, require JWT authentication
+        token = self._extract_token(request)
+        
+        if not token:
+            logger.warning(
+                f"Missing JWT token | Request: {request.method} {request.path} | "
+                f"IP: {request.META.get('REMOTE_ADDR', 'unknown')}"
+            )
+            return JsonResponse(
+                {
+                    "error": "Authentication required",
+                    "detail": "Invalid or expired token"
+                },
+                status=401
+            )
+
+        # Authenticate the token
+        auth_result = self._authenticate_token(request, token)
+        
+        if auth_result is None:
+            return JsonResponse(
+                {
+                    "error": "Authentication required",
+                    "detail": "Invalid or expired token"
+                },
+                status=401
+            )
+
+        user, validated_token = auth_result
+
+        # Check if user is active
+        if not user.is_active:
+            logger.warning(
+                f"Inactive user attempted access | User: {user.username} | "
+                f"Request: {request.method} {request.path} | "
+                f"IP: {request.META.get('REMOTE_ADDR', 'unknown')}"
+            )
+            return JsonResponse(
+                {
+                    "error": "Authentication required",
+                    "detail": "Invalid or expired token"
+                },
+                status=403
+            )
+
+        # Set user and auth on request for DRF compatibility
+        request.user = user
+        request.auth = validated_token
+
+        # Continue with the request
+        return self.get_response(request)

--- a/backend/vibera/settings.py
+++ b/backend/vibera/settings.py
@@ -103,6 +103,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "vibera.middleware.JWTAuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "vibera.middleware.RequestResponseLoggingMiddleware",
@@ -199,6 +200,13 @@ SIMPLE_JWT = {
     "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
     "TOKEN_TYPE_CLAIM": "token_type",
 }
+
+# API Authentication Middleware Configuration
+API_AUTH_MIDDLEWARE_PUBLIC_PATHS = [
+    "/api/auth/",  # Djoser JWT authentication endpoints
+    "/admin/",  # Django admin interface
+    "/api/users/auth/2fa/",  # 2FA authentication endpoints
+]
 
 # Djoser Configuration
 DJOSER = {

--- a/backend/vibera/tests.py
+++ b/backend/vibera/tests.py
@@ -1,0 +1,368 @@
+"""
+Integration tests for JWT Authentication Middleware.
+
+This test suite verifies that:
+- Middleware integrates correctly with existing DRF authentication
+- Public endpoints remain accessible without authentication
+- Protected endpoints require valid JWT tokens
+- Invalid/missing tokens are properly rejected
+- Middleware doesn't break existing functionality
+"""
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from rest_framework.test import APIClient
+from rest_framework import status
+from rest_framework_simplejwt.tokens import RefreshToken
+
+User = get_user_model()
+
+
+class JWTAuthenticationMiddlewareIntegrationTests(TestCase):
+    """
+    Integration tests for JWT Authentication Middleware.
+    
+    Tests verify that the middleware correctly:
+    - Allows public endpoints without authentication
+    - Requires authentication for protected endpoints
+    - Validates JWT tokens properly
+    - Integrates with DRF authentication system
+    """
+
+    def setUp(self):
+        """Set up test data and clients"""
+        # Create test user
+        self.user = User.objects.create_user(
+            email="testuser@example.com",
+            username="testuser",
+            password="testpass123",
+            is_active=True,
+        )
+        
+        # Create inactive user for testing
+        self.inactive_user = User.objects.create_user(
+            email="inactive@example.com",
+            username="inactive",
+            password="testpass123",
+            is_active=False,
+        )
+        
+        # Create API clients
+        self.client = APIClient()
+        self.authenticated_client = APIClient()
+        
+        # Generate JWT token for authenticated client
+        refresh = RefreshToken.for_user(self.user)
+        self.access_token = str(refresh.access_token)
+        self.authenticated_client.credentials(
+            HTTP_AUTHORIZATION=f'Bearer {self.access_token}'
+        )
+        
+        # Generate token for inactive user
+        refresh_inactive = RefreshToken.for_user(self.inactive_user)
+        self.inactive_token = str(refresh_inactive.access_token)
+        
+    def get_auth_token(self, user):
+        """Helper method to get JWT token for a user"""
+        refresh = RefreshToken.for_user(user)
+        return str(refresh.access_token)
+
+    def test_public_auth_endpoint_accessible_without_token(self):
+        """
+        Test that public authentication endpoints are accessible without JWT token.
+        
+        The middleware should allow access to /api/auth/ endpoints without authentication.
+        """
+        # Test JWT token creation endpoint (public)
+        response = self.client.post(
+            '/api/auth/jwt/create/',
+            {
+                'username': 'testuser',
+                'password': 'testpass123'
+            },
+            format='json'
+        )
+        # Should succeed (200 or 201 depending on implementation)
+        self.assertIn(response.status_code, [status.HTTP_200_OK, status.HTTP_201_CREATED])
+        self.assertIn('access', response.data)
+        self.assertIn('refresh', response.data)
+
+    def test_public_2fa_endpoint_accessible_without_token(self):
+        """
+        Test that 2FA endpoints are accessible without JWT token.
+        
+        The middleware should allow access to /api/users/auth/2fa/ endpoints.
+        """
+        # Test 2FA login request endpoint (public)
+        response = self.client.post(
+            '/api/users/auth/2fa/login/',
+            {
+                'username': 'testuser',
+                'password': 'testpass123'
+            },
+            format='json'
+        )
+        # Should not return 401 (authentication required)
+        # May return 400/404 if endpoint doesn't exist or validation fails, but not 401
+        self.assertNotEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_protected_endpoint_requires_authentication(self):
+        """
+        Test that protected API endpoints require JWT authentication.
+        
+        The middleware should reject requests to protected endpoints without tokens.
+        """
+        # Test protected mood endpoint without token
+        response = self.client.get('/api/moods/')
+        
+        # Should return 401 Unauthorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn('error', response.json())
+        self.assertIn('Authentication required', response.json()['error'])
+
+    def test_protected_endpoint_with_valid_token(self):
+        """
+        Test that protected endpoints work with valid JWT token.
+        
+        The middleware should allow access when a valid token is provided.
+        """
+        # Test protected mood endpoint with valid token
+        response = self.authenticated_client.get('/api/moods/')
+        
+        # Should succeed (200 OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('count', response.data)
+        self.assertIn('data', response.data)
+
+    def test_protected_endpoint_with_invalid_token(self):
+        """
+        Test that protected endpoints reject invalid JWT tokens.
+        
+        The middleware should return 401 for malformed or invalid tokens.
+        """
+        # Test with invalid token
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer invalid_token_12345')
+        response = self.client.get('/api/moods/')
+        
+        # Should return 401 Unauthorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn('error', response.json())
+        self.assertIn('Authentication required', response.json()['error'])
+
+    def test_protected_endpoint_with_malformed_header(self):
+        """
+        Test that protected endpoints reject malformed Authorization headers.
+        
+        The middleware should handle various malformed header formats.
+        """
+        # Test with missing Bearer prefix
+        self.client.credentials(HTTP_AUTHORIZATION=self.access_token)
+        response = self.client.get('/api/moods/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        
+        # Test with wrong format
+        self.client.credentials(HTTP_AUTHORIZATION=f'Token {self.access_token}')
+        response = self.client.get('/api/moods/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        
+        # Test with empty header
+        self.client.credentials(HTTP_AUTHORIZATION='')
+        response = self.client.get('/api/moods/')
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_protected_endpoint_with_missing_header(self):
+        """
+        Test that protected endpoints reject requests without Authorization header.
+        
+        The middleware should return 401 when no Authorization header is present.
+        """
+        # Clear any credentials
+        self.client.credentials()
+        response = self.client.get('/api/moods/')
+        
+        # Should return 401 Unauthorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn('error', response.json())
+
+    def test_inactive_user_rejected(self):
+        """
+        Test that inactive users are rejected even with valid token.
+        
+        The middleware should return 403 for inactive users.
+        """
+        # Test with inactive user's token
+        self.client.credentials(HTTP_AUTHORIZATION=f'Bearer {self.inactive_token}')
+        response = self.client.get('/api/moods/')
+        
+        # Should return 403 Forbidden
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertIn('error', response.json())
+
+    def test_middleware_sets_user_on_request(self):
+        """
+        Test that middleware correctly sets user and auth on request object.
+        
+        This ensures DRF views can access request.user and request.auth.
+        """
+        # Make request to protected endpoint
+        response = self.authenticated_client.get('/api/moods/')
+        
+        # Should succeed
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        
+        # The fact that we got a 200 means the view could access request.user
+        # We can verify this by checking the response contains user-specific data
+        # (moods endpoint filters by user, so empty list is expected for new user)
+        self.assertIsInstance(response.data, dict)
+
+    def test_non_api_routes_bypassed(self):
+        """
+        Test that non-API routes are not affected by the middleware.
+        
+        The middleware should only apply to /api/ routes.
+        """
+        # Test admin route (should not require JWT, handled by Django's auth)
+        response = self.client.get('/admin/')
+        # Admin may redirect or require login, but shouldn't be blocked by JWT middleware
+        # Status could be 302 (redirect) or 200, but not 401 from JWT middleware
+        self.assertNotEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_drf_authentication_integration(self):
+        """
+        Test that middleware integrates correctly with DRF's authentication system.
+        
+        DRF views should be able to use request.user set by the middleware.
+        """
+        # Create a mood entry to test user-specific filtering
+        from moods.models import Mood
+        mood = Mood.objects.create(
+            user=self.user,
+            emoji="😊",
+            reason="Test mood"
+        )
+        
+        # Access protected endpoint with valid token
+        response = self.authenticated_client.get('/api/moods/')
+        
+        # Should succeed and return user's moods
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['data'][0]['id'], mood.id)
+
+    def test_post_request_with_authentication(self):
+        """
+        Test that POST requests to protected endpoints work with authentication.
+        
+        The middleware should allow authenticated POST requests.
+        """
+        # Create mood entry with authenticated client
+        response = self.authenticated_client.post(
+            '/api/moods/',
+            {
+                'emoji': '😊',
+                'reason': 'Feeling great!'
+            },
+            format='json'
+        )
+        
+        # Should succeed
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn('data', response.data)
+
+    def test_post_request_without_authentication(self):
+        """
+        Test that POST requests to protected endpoints are rejected without authentication.
+        
+        The middleware should reject unauthenticated POST requests.
+        """
+        # Try to create mood entry without token
+        response = self.client.post(
+            '/api/moods/',
+            {
+                'emoji': '😊',
+                'reason': 'Feeling great!'
+            },
+            format='json'
+        )
+        
+        # Should return 401 Unauthorized
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn('error', response.json())
+
+    def test_public_paths_configuration(self):
+        """
+        Test that all configured public paths are accessible without authentication.
+        
+        This verifies the API_AUTH_MIDDLEWARE_PUBLIC_PATHS setting works correctly.
+        """
+        # Test /api/auth/ endpoints (JWT creation)
+        response = self.client.post(
+            '/api/auth/jwt/create/',
+            {
+                'username': 'testuser',
+                'password': 'testpass123'
+            },
+            format='json'
+        )
+        self.assertNotEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        
+        # Test /api/users/auth/2fa/ endpoints
+        response = self.client.post(
+            '/api/users/auth/2fa/login/',
+            {
+                'username': 'testuser',
+                'password': 'testpass123'
+            },
+            format='json'
+        )
+        self.assertNotEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_error_response_format(self):
+        """
+        Test that error responses follow the expected format.
+        
+        The middleware should return consistent JSON error responses.
+        """
+        # Make unauthenticated request
+        response = self.client.get('/api/moods/')
+        
+        # Check response format
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        data = response.json()
+        self.assertIn('error', data)
+        self.assertIn('detail', data)
+        self.assertEqual(data['error'], 'Authentication required')
+
+    def test_token_expiration_handling(self):
+        """
+        Test that expired tokens are properly rejected.
+        
+        Note: This test may require manipulating token expiration,
+        which is complex. We'll test that invalid tokens are rejected.
+        """
+        # Use a clearly invalid token format
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer expired.invalid.token')
+        response = self.client.get('/api/moods/')
+        
+        # Should return 401
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_multiple_requests_with_same_token(self):
+        """
+        Test that the same token can be used for multiple requests.
+        
+        The middleware should handle token validation consistently.
+        """
+        # Make multiple requests with the same token
+        response1 = self.authenticated_client.get('/api/moods/')
+        response2 = self.authenticated_client.get('/api/moods/')
+        response3 = self.authenticated_client.post(
+            '/api/moods/',
+            {'emoji': '😊', 'reason': 'Test'},
+            format='json'
+        )
+        
+        # All should succeed
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        self.assertEqual(response2.status_code, status.HTTP_200_OK)
+        self.assertEqual(response3.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
# Pull Request

## Summary
This PR adds JWT authentication middleware for API endpoints and enhances it to properly handle inactive users with improved error logging. The middleware validates JWT tokens for all protected API routes while allowing public endpoints (like authentication and 2FA) to remain accessible without tokens.

---

## Type of Change
Select all that apply:

- [x] Feature
- [x] Bug fix
- [ ] Refactor (no behavior change)
- [ ] Chore / tooling
- [ ] Documentation

---

## What Changed
Clearly explain **what** was added, removed, or modified.

- Added `JWTAuthenticationMiddleware` class that validates JWT tokens for protected API endpoints
- Configured middleware in `settings.py` with public paths for authentication endpoints (`/api/auth/`, `/api/users/auth/2fa/`, `/admin/`)
- Enhanced authentication to detect and handle inactive users with proper error responses (403 Forbidden)
- Improved error logging to distinguish between different authentication failure types (invalid token, inactive user, etc.)
- Added comprehensive integration test suite (368 lines) covering all authentication scenarios
- Removed unused code from `db_logging.py` (wrapped_close assignment)

---

## Why This Change Is Needed
Explain **why** this change is required.  
What problem does it solve? What requirement does it fulfill?

- **Security**: All API endpoints now require JWT authentication, preventing unauthorized access to protected resources
- **User Management**: Inactive users are properly blocked from accessing the API even if they have valid tokens
- **Consistency**: Standardizes authentication across all API endpoints using DRF's JWT authentication system
- **Observability**: Enhanced logging provides better visibility into authentication failures for security monitoring
- **Testing**: Comprehensive test coverage ensures the middleware works correctly and doesn't break existing functionality

---

## How to Test
Provide clear steps so reviewers can test this PR.

1. Start the backend server
2. **Test public endpoints (should work without token):**
   - Call `POST /api/auth/jwt/create/` with username/password - should return JWT tokens
   - Call `POST /api/users/auth/2fa/login/` - should not require authentication
3. **Test protected endpoints (should require token):**
   - Call `GET /api/moods/` without token - should return 401 Unauthorized
   - Call `GET /api/moods/` with valid JWT token in `Authorization: Bearer <token>` header - should return 200 OK
   - Call `GET /api/moods/` with invalid token - should return 401 Unauthorized
4. **Test inactive user handling:**
   - Create an inactive user and generate a JWT token for them
   - Call `GET /api/moods/` with inactive user's token - should return 403 Forbidden
5. **Run integration tests:**
   - Execute `python manage.py test vibera.tests.JWTAuthenticationMiddlewareIntegrationTests`

---

## Screenshots / Recordings (Frontend Only)
If this PR includes UI changes, attach screenshots or screen recordings.

N/A - Backend-only changes

---

## Checklist
Before requesting review, ensure the following:

- [x] Branch is up to date with `main`
- [x] Code builds and runs locally
- [x] No secrets or `.env` files committed
- [x] No debug logs or commented-out code
- [x] Changes are scoped to this PR only
- [x] Naming and structure follow project conventions

---

## Backend Checklist (if applicable)
- [x] Input validation added
- [x] Permissions / auth checks applied
- [x] API responses follow standard format
- [ ] Migrations included (if needed)

---

## Frontend Checklist (if applicable)
- [ ] Responsive on mobile
- [ ] Loading / empty states handled
- [ ] No hardcoded values
- [ ] Components are reusable where possible

---

## Related Tickets
Link related Notion tickets or issues.

Example:
- Vibera-43

---

## Additional Notes
Anything reviewers should be aware of (trade-offs, follow-ups, known issues).

- The middleware is positioned after Django's `AuthenticationMiddleware` in the middleware stack to ensure proper integration
- Public paths are configurable via `API_AUTH_MIDDLEWARE_PUBLIC_PATHS` setting in `settings.py`
- The middleware sets `request.user` and `request.auth` for DRF compatibility, allowing views to access authenticated user information
- Error responses use generic messages ("Invalid or expired token") to avoid leaking information about user accounts
- Comprehensive test suite covers edge cases including malformed headers, missing tokens, inactive users, and integration with DRF views

---

**Reviewer Notes:**  
Please focus on correctness, clarity, and security.
